### PR TITLE
fix(docs): render LaTeX formulas and fix build warnings

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -54,4 +54,4 @@ result = modeler.result  # InterpolationResult with .interpolated array
 
 - [Installation](getting-started/installation.md)
 - [Quick Start](getting-started/quickstart.md)
-- [API Reference](reference/)
+- [API Reference](reference/index.md)

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,19 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true,
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex",
+  },
+};
+
+document$.subscribe(() => {
+  MathJax.startup.output.clearCache();
+  MathJax.typesetClear();
+  MathJax.texReset();
+  MathJax.typesetPromise();
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ markdown_extensions:
   - toc: { permalink: true }
 
 extra_javascript:
+  - javascripts/mathjax.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 nav:


### PR DESCRIPTION
## Summary

- Add `docs/javascripts/mathjax.js` config required by `pymdownx.arithmatex` generic mode to register `\(...\)` / `\[...\]` delimiters and the `arithmatex` CSS class
- Load the config script **before** MathJax in `mkdocs.yml`
- Fix unrecognized relative link warning for `reference/` in `index.md`

## Test plan

- [ ] `uv run mkdocs build --strict` — no warnings
- [ ] LaTeX renders on [Models](https://giocaizzi.github.io/py3dinterpolations/guide/models/) (IDW formula) and [Preprocessing](https://giocaizzi.github.io/py3dinterpolations/guide/preprocessing/) (normalization/standardization formulas)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)